### PR TITLE
Avoid exposing private data using example commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Cryptomator CLI depends on a Java 8 JRE. In addition the JCE unlimited strength 
 java -jar cryptomator-cli-x.y.z.jar \
     --vault demoVault=/path/to/vault --password demoVault=topSecret \
     --vault otherVault=/path/to/differentVault --passwordfile otherVault=/path/to/fileWithPassword \
-    --bind 0.0.0.0 --port 8080
+    --bind 127.0.0.1 --port 8080
 # you can now mount http://localhost:8080/demoVault/
 ```
 


### PR DESCRIPTION
The example commandline from the _README.md_ does not bind to `localhost` exclusively but instead **binds to all interfaces**, so the decrypted files can be accessed by anyone on the network.

This PR fixes that by binding exclusively to `127.0.0.1`.

At least on _Windows_ this has the neat side-effect that the Windows-Firewall is not asking for permission to allow a server, which it does when binding to other interfaces than `localhost`.