### PR TITLE
Fix CPU hogging when running in background.

### DIFF
--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -116,12 +116,18 @@ public class CryptomatorCli {
 	private static void waitForShutdown(Runnable runnable) {
 		Runtime.getRuntime().addShutdownHook(new Thread(runnable));
 		LOG.info("Press Ctrl+C to terminate.");
+
+		// Block the main thread infinitely as otherwise when using
+		// Fuse mounts the application quits immediately.
 		try {
-			while (true) {
-				System.in.read();
+			Object mainThreadBlockLock = new Object();
+			synchronized (mainThreadBlockLock) {
+				while (true) {
+					mainThreadBlockLock.wait();
+				}
 			}
-		} catch (IOException e) {
-			e.printStackTrace();
+		} catch (Exception e) {
+			LOG.error("Main thread blocking failed.");
 		}
 	}
 }


### PR DESCRIPTION
Using "System.in.read()" to block the main thread only works if the
application is running in the foreground (user provides stdin). If
running in background or if stdin is otherwise not blocking this causes
100% cpu usage.

Fix by blocking the main thread infinitely with a condition variable.
This retains the old functionality (CTRL-C still works to quit the
application).

Fixes #35 