### PR TITLE
set FUSE subtype and fsname by default

### DIFF
--- a/src/main/java/org/cryptomator/cli/Args.java
+++ b/src/main/java/org/cryptomator/cli/Args.java
@@ -80,16 +80,9 @@ public class Args {
 				.hasArgs() //
 				.build());
 		OPTIONS.addOption(Option.builder() //
-				.longOpt("subtype") //
-				.argName("fuse subtype") //
-				.desc("Format must be vaultName=fuse subtype") //
-				.valueSeparator() //
-				.hasArgs() //
-				.build());
-		OPTIONS.addOption(Option.builder() //
-				.longOpt("fsname") //
-				.argName("fuse fsname") //
-				.desc("Format must be vaultName=fuse fsname") //
+				.longOpt("mountFlags") //
+				.argName("fuse mount flags") //
+				.desc("Format must be vaultName=fuse mount flags") //
 				.valueSeparator() //
 				.hasArgs() //
 				.build());
@@ -98,8 +91,7 @@ public class Args {
 	private final String bindAddr;
 	private final int port;
 	private final boolean hasValidWebDavConfig;
-	private final Properties fuseSubType;
-	private final Properties fuseFSName;
+	private final Properties fuseMountFlags;
 	private final Properties vaultPaths;
 	private final Properties vaultPasswords;
 	private final Properties vaultPasswordFiles;
@@ -121,8 +113,7 @@ public class Args {
 		this.vaultPasswordFiles = commandLine.getOptionProperties("passwordfile");
 		this.passwordStrategies = new HashMap<>();
 		this.fuseMountPoints = commandLine.getOptionProperties("fusemount");
-		this.fuseFSName = commandLine.getOptionProperties("fsname");
-		this.fuseSubType = commandLine.getOptionProperties("subtype");
+		this.fuseMountFlags = commandLine.getOptionProperties("mountFlags");
 	}
 
 	public boolean hasValidWebDavConf() {
@@ -133,12 +124,8 @@ public class Args {
 		return bindAddr;
 	}
 
-	public String fuseFSName(String vaultName) {
-		return fuseFSName.getProperty(vaultName);
-	}
-
-	public String fuseSubType(String vaultName) {
-		return fuseSubType.getProperty(vaultName);
+	public String fuseMountFlags(String vaultName) {
+		return fuseMountFlags.getProperty(vaultName);
 	}
 
 	public int getPort() {

--- a/src/main/java/org/cryptomator/cli/Args.java
+++ b/src/main/java/org/cryptomator/cli/Args.java
@@ -79,11 +79,27 @@ public class Args {
 				.valueSeparator() //
 				.hasArgs() //
 				.build());
+		OPTIONS.addOption(Option.builder() //
+				.longOpt("subtype") //
+				.argName("fuse subtype") //
+				.desc("Format must be vaultName=fuse subtype") //
+				.valueSeparator() //
+				.hasArgs() //
+				.build());
+		OPTIONS.addOption(Option.builder() //
+				.longOpt("fsname") //
+				.argName("fuse fsname") //
+				.desc("Format must be vaultName=fuse fsname") //
+				.valueSeparator() //
+				.hasArgs() //
+				.build());
 	}
 
 	private final String bindAddr;
 	private final int port;
 	private final boolean hasValidWebDavConfig;
+	private final Properties fuseSubType;
+	private final Properties fuseFSName;
 	private final Properties vaultPaths;
 	private final Properties vaultPasswords;
 	private final Properties vaultPasswordFiles;
@@ -105,6 +121,8 @@ public class Args {
 		this.vaultPasswordFiles = commandLine.getOptionProperties("passwordfile");
 		this.passwordStrategies = new HashMap<>();
 		this.fuseMountPoints = commandLine.getOptionProperties("fusemount");
+		this.fuseFSName = commandLine.getOptionProperties("fsname");
+		this.fuseSubType = commandLine.getOptionProperties("subtype");
 	}
 
 	public boolean hasValidWebDavConf() {
@@ -113,6 +131,14 @@ public class Args {
 
 	public String getBindAddr() {
 		return bindAddr;
+	}
+
+	public String fuseFSName(String vaultName) {
+		return fuseFSName.getProperty(vaultName);
+	}
+
+	public String fuseSubType(String vaultName) {
+		return fuseSubType.getProperty(vaultName);
 	}
 
 	public int getPort() {

--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -81,7 +81,7 @@ public class CryptomatorCli {
 
 			Path fuseMountPoint = args.getFuseMountPoint(vaultName);
 			if (fuseMountPoint != null) {
-				FuseMount newMount = new FuseMount(vaultRoot, fuseMountPoint);
+				FuseMount newMount = new FuseMount(vaultRoot, vaultPath, fuseMountPoint);
 				if (newMount.mount()) {
 					mounts.add(newMount);
 				}

--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -81,9 +81,8 @@ public class CryptomatorCli {
 
 			Path fuseMountPoint = args.getFuseMountPoint(vaultName);
 			if (fuseMountPoint != null) {
-				String fsname = args.fuseFSName(vaultName);
-				String subtype = args.fuseSubType(vaultName);
-				FuseMount newMount = new FuseMount(vaultRoot, vaultPath, fuseMountPoint, fsname, subtype);
+				String mountFlags = args.fuseMountFlags(vaultName);
+				FuseMount newMount = new FuseMount(vaultRoot, vaultPath, fuseMountPoint, mountFlags);
 				if (newMount.mount()) {
 					mounts.add(newMount);
 				}

--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -82,7 +82,7 @@ public class CryptomatorCli {
 			Path fuseMountPoint = args.getFuseMountPoint(vaultName);
 			if (fuseMountPoint != null) {
 				String mountFlags = args.fuseMountFlags(vaultName);
-				FuseMount newMount = new FuseMount(vaultRoot, vaultPath, fuseMountPoint, mountFlags);
+				FuseMount newMount = new FuseMount(vaultRoot, fuseMountPoint, mountFlags);
 				if (newMount.mount()) {
 					mounts.add(newMount);
 				}

--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -81,7 +81,9 @@ public class CryptomatorCli {
 
 			Path fuseMountPoint = args.getFuseMountPoint(vaultName);
 			if (fuseMountPoint != null) {
-				FuseMount newMount = new FuseMount(vaultRoot, vaultPath, fuseMountPoint);
+				String fsname = args.fuseFSName(vaultName);
+				String subtype = args.fuseSubType(vaultName);
+				FuseMount newMount = new FuseMount(vaultRoot, vaultPath, fuseMountPoint, fsname, subtype);
 				if (newMount.mount()) {
 					mounts.add(newMount);
 				}

--- a/src/main/java/org/cryptomator/cli/frontend/FuseMount.java
+++ b/src/main/java/org/cryptomator/cli/frontend/FuseMount.java
@@ -16,15 +16,13 @@ public class FuseMount {
 	private static final Logger LOG = LoggerFactory.getLogger(FuseMount.class);
 
 	private Path vaultRoot;
-	private Path vaultPath;
 	private Path mountPoint;
 	private Mount mnt;
 	private String mountFlags;
 
-	public FuseMount(Path vaultRoot, Path vaultPath, Path mountPoint, String mountFlags) {
+	public FuseMount(Path vaultRoot, Path mountPoint, String mountFlags) {
 		this.vaultRoot = vaultRoot;
 		this.mountPoint = mountPoint;
-		this.vaultPath = vaultPath;
 		this.mountFlags = mountFlags;
 		this.mnt = null;
 	}

--- a/src/main/java/org/cryptomator/cli/frontend/FuseMount.java
+++ b/src/main/java/org/cryptomator/cli/frontend/FuseMount.java
@@ -14,12 +14,14 @@ public class FuseMount {
 	private static final Logger LOG = LoggerFactory.getLogger(FuseMount.class);
 
 	private Path vaultRoot;
+	private Path vaultPath;
 	private Path mountPoint;
 	private Mount mnt;
 
-	public FuseMount(Path vaultRoot, Path mountPoint) {
+	public FuseMount(Path vaultRoot, Path vaultPath, Path mountPoint) {
 		this.vaultRoot = vaultRoot;
 		this.mountPoint = mountPoint;
+		this.vaultPath = vaultPath;
 		this.mnt = null;
 	}
 
@@ -31,7 +33,14 @@ public class FuseMount {
 
 		try {
 			Mounter mounter = FuseMountFactory.getMounter();
-			EnvironmentVariables envVars = EnvironmentVariables.create().withFlags(mounter.defaultMountFlags())
+			String[] mountFlags = mounter.defaultMountFlags();
+			String[] newMountFlags = new String[mountFlags.length+2];
+			for (int i = 0 ; i < mountFlags.length ; i++) {
+				newMountFlags[i] = mountFlags[i];
+			}
+			newMountFlags[mountFlags.length] = "-osubtype=cryptomator";
+			newMountFlags[mountFlags.length+1] ="-ofsname=cryptomator@"+vaultPath;
+			EnvironmentVariables envVars = EnvironmentVariables.create().withFlags(newMountFlags)
 					.withMountPoint(mountPoint).build();
 			mnt = mounter.mount(vaultRoot, envVars);
 			LOG.info("Mounted to {}", mountPoint);


### PR DESCRIPTION

Currently, a mounted cryptomator volume shows up in "/proc/self/mountinfo" in linux as follows:

```
41 33 0:34 / /home/_/cryptomator rw,nosuid,nodev,relatime - fuse.fusefs-1001772408 fusefs-1001772408 rw,user_id=500,group_id=500

```

Notice that there is no way of knowing if this entry belongs to cryptomator because "fuse.fusefs-1001772408" is not very meaningful because the numbers are randomly generated i think from here[1]

With this patch, the above line shows up as below
```
49 33 0:42 / /home/ink/bbb rw,nosuid,nodev,relatime - fuse.cryptomator cryptomator@/home/ink/.vaults/cryptomator rw,user_id=500,group_id=500
```
The above line has the following improvements :-
1. The path to the vault is displayed.
2. The file system entry has the correct entry of "fuse.cryptomator".
3. The path to the vault starts with "cryptomator@". This is the standard way of identifying FUSE mounts that do not set the file system type.

The last two makes it easy to identify cryptomator volumes and are necessary for identification by other tools like file managers and desktop environments.

[1] https://github.com/SerCeMan/jnr-fuse/blob/c5d071af150a191c72b6ed91fd5865ffa1853d4a/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java#L315