### PR TITLE
Fixing Docker parameters order in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ docker run --rm -p 8080:8080 \
     -v /path/to/vault:/vaults/vault \
     -v /path/to/differentVault:/vaults/differentVault \
     -v /path/to/fileWithPassword:/passwordFile \
-    --bind 0.0.0.0 --port 8080 \
     cryptomator/cli \
+    --bind 0.0.0.0 --port 8080 \
     --vault demoVault=/vaults/vault --password demoVault=topSecret \
     --vault otherVault=/vaults/differentVault --passwordfile otherVault=/passwordFile
 # you can now mount http://localhost:8080/demoVault/
@@ -97,8 +97,8 @@ docker run --rm --network=host \
     -v /path/to/vault:/vaults/vault \
     -v /path/to/differentVault:/vaults/differentVault \
     -v /path/to/fileWithPassword:/passwordFile \
-    --bind 127.0.0.1 --port 8080 \
     cryptomator/cli \
+    --bind 127.0.0.1 --port 8080 \
     --vault demoVault=/vaults/vault --password demoVault=topSecret \
     --vault otherVault=/vaults/differentVault --passwordfile otherVault=/passwordFile
 # you can now mount http://localhost:8080/demoVault/


### PR DESCRIPTION
Hello,
The exemple of Docker usage in `README.md` is wrong. 
`--bind 0.0.0.0 --port 8080` parameter order is shown as before image name and execute the exemple will output:
`unknown flag: --bind`.
This pull request does change the Docker parameters to the right order.