### PR TITLE
This pull request updates both cryptomator dependancies to the latest version (as of Jun '23)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<cryptofs.version>2.6.5</cryptofs.version>
-		<webdav-nio.version>1.2.6</webdav-nio.version>
+		<webdav-nio.version>2.0.3</webdav-nio.version>
 		<commons.cli.version>1.5.0</commons.cli.version>
 		<logback.version>1.2.9</logback.version>
 		<fuse-nio.version>1.3.3</fuse-nio.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,42 +42,17 @@
 			<artifactId>cryptofs</artifactId>
 			<version>${cryptofs.version}</version>
 		</dependency>
-
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>30.1.1-jre</version>
-		</dependency>
-
 		<dependency>
 			<groupId>org.cryptomator</groupId>
 			<artifactId>webdav-nio-adapter</artifactId>
 			<version>${webdav-nio.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.cryptomator</groupId>
 			<artifactId>fuse-nio-adapter</artifactId>
 			<version>${fuse-nio.version}</version>
-			<exclusions>
-        		<exclusion>
-            		<groupId>com.google.dagger</groupId>
-            		<artifactId>dagger</artifactId>
-        		</exclusion>
-    		</exclusions>
 		</dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.31</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.dagger</groupId>
-			<artifactId>dagger</artifactId>
-			<version>2.39.1</version>
-		</dependency>
 		<!-- Commons -->
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<url>https://github.com/cryptomator/cli</url>
 
 	<properties>
-		<cryptofs.version>2.3.1</cryptofs.version>
+		<cryptofs.version>2.6.5</cryptofs.version>
 		<webdav-nio.version>1.2.6</webdav-nio.version>
 		<commons.cli.version>1.5.0</commons.cli.version>
 		<logback.version>1.2.9</logback.version>
@@ -42,17 +42,42 @@
 			<artifactId>cryptofs</artifactId>
 			<version>${cryptofs.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>30.1.1-jre</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.cryptomator</groupId>
 			<artifactId>webdav-nio-adapter</artifactId>
 			<version>${webdav-nio.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.cryptomator</groupId>
 			<artifactId>fuse-nio-adapter</artifactId>
 			<version>${fuse-nio.version}</version>
+			<exclusions>
+        		<exclusion>
+            		<groupId>com.google.dagger</groupId>
+            		<artifactId>dagger</artifactId>
+        		</exclusion>
+    		</exclusions>
 		</dependency>
 
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.31</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.dagger</groupId>
+			<artifactId>dagger</artifactId>
+			<version>2.39.1</version>
+		</dependency>
 		<!-- Commons -->
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/src/main/java/org/cryptomator/cli/frontend/WebDav.java
+++ b/src/main/java/org/cryptomator/cli/frontend/WebDav.java
@@ -1,5 +1,8 @@
 package org.cryptomator.cli.frontend;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 
@@ -13,14 +16,16 @@ public class WebDav {
 	private static final Logger LOG = LoggerFactory.getLogger(WebDav.class);
 
 	private final WebDavServer server;
-	private ArrayList<WebDavServletController> servlets;
+	private ArrayList<WebDavServletController> servlets = new ArrayList<>();
 
 	public WebDav(String bindAddr, int port) {
-		servlets = new ArrayList<>();
-		server = WebDavServer.create();
-		server.bind(bindAddr, port);
-		server.start();
-		LOG.info("WebDAV server started: {}:{}", bindAddr, port);
+		try {
+			server = WebDavServer.create(new InetSocketAddress(InetAddress.getByName(bindAddr), port));
+			server.start();
+			LOG.info("WebDAV server started: {}:{}", bindAddr, port);
+		} catch (UnknownHostException e) {
+			throw new IllegalStateException("Error creating WebDavServer", e);
+		}
 	}
 
 	public void stop() {


### PR DESCRIPTION
This pull request is a very rough update to bump the versions of dependancies cryptofs (v2.3.1 -> 2.6.5) and webdav-nio (v1.2.6 -> 2.0.3) to the latest versions.

I'm not a java expert so this is more a proof of concept pull request to attempt to drive interaction from the cryptomator team to release a new version of cryptomator cli with the latest versions. **These changes has not been fully tested, but will allow existing files in a vault to be browsed and new file written through webdav.**

* The 1st bump of cryptofs to 2.6.5 only required some dependancy version locking in the pom file.
* The 2nd bump of webdav-nio to 2.0.3 required some code changes to cryptomator/cli/frontend/WebDav.java due to this code change in webdav-nio: https://github.com/cryptomator/webdav-nio-adapter/pull/44/commits/1b86572b7a4713ab9fd0159004560b5e19afd0db