### PR TITLE
Adds --version option

### DIFF
--- a/src/main/java/org/cryptomator/cli/Args.java
+++ b/src/main/java/org/cryptomator/cli/Args.java
@@ -112,6 +112,10 @@ public class Args {
 		this.passwordStrategies = new HashMap<>();
 		this.fuseMountPoints = commandLine.getOptionProperties("fusemount");
 		this.hasVersion = commandLine.hasOption("version");
+
+		if (hasVersion()) {
+			printVersionAndExit();
+		}
 	}
 
 	public boolean hasValidWebDavConf() {
@@ -172,5 +176,11 @@ public class Args {
 
 	public boolean hasVersion() {
 		return hasVersion;
+	}
+
+	public void printVersionAndExit() {
+		String version = Version.IMPLEMENTATION_VERSION;
+		System.out.println(version);
+		System.exit(0);
 	}
 }

--- a/src/main/java/org/cryptomator/cli/Args.java
+++ b/src/main/java/org/cryptomator/cli/Args.java
@@ -79,6 +79,11 @@ public class Args {
 				.valueSeparator() //
 				.hasArgs() //
 				.build());
+		OPTIONS.addOption(Option.builder() //
+				.longOpt("version") //
+				.desc("Prints version and exits") //
+				.hasArg(false)
+				.build());
 	}
 
 	private final String bindAddr;
@@ -89,6 +94,7 @@ public class Args {
 	private final Properties vaultPasswordFiles;
 	private final Map<String, PasswordStrategy> passwordStrategies;
 	private final Properties fuseMountPoints;
+	private final boolean hasVersion;
 
 	public Args(CommandLine commandLine) throws ParseException {
 		if (commandLine.hasOption("bind") && commandLine.hasOption("port")) {
@@ -105,6 +111,7 @@ public class Args {
 		this.vaultPasswordFiles = commandLine.getOptionProperties("passwordfile");
 		this.passwordStrategies = new HashMap<>();
 		this.fuseMountPoints = commandLine.getOptionProperties("fusemount");
+		this.hasVersion = commandLine.hasOption("version");
 	}
 
 	public boolean hasValidWebDavConf() {
@@ -161,5 +168,9 @@ public class Args {
 		}
 		Path mountPointPath = Paths.get(mountPoint);
 		return mountPointPath;
+	}
+
+	public boolean hasVersion() {
+		return hasVersion;
 	}
 }

--- a/src/main/java/org/cryptomator/cli/Args.java
+++ b/src/main/java/org/cryptomator/cli/Args.java
@@ -112,10 +112,6 @@ public class Args {
 		this.passwordStrategies = new HashMap<>();
 		this.fuseMountPoints = commandLine.getOptionProperties("fusemount");
 		this.hasVersion = commandLine.hasOption("version");
-
-		if (hasVersion()) {
-			printVersionAndExit();
-		}
 	}
 
 	public boolean hasValidWebDavConf() {
@@ -176,11 +172,5 @@ public class Args {
 
 	public boolean hasVersion() {
 		return hasVersion;
-	}
-
-	public void printVersionAndExit() {
-		String version = Version.IMPLEMENTATION_VERSION;
-		System.out.println(version);
-		System.exit(0);
 	}
 }

--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -75,6 +75,7 @@ public class CryptomatorCli {
 	}
 
 	private static void startup(Args args) throws IOException {
+		LOG.info("Starting Cryptomator CLI {}", Version.IMPLEMENTATION_VERSION);
 		Optional<WebDav> server = initWebDavServer(args);
 		ArrayList<FuseMount> mounts = new ArrayList<>();
 

--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -39,6 +39,13 @@ public class CryptomatorCli {
 	public static void main(String[] rawArgs) throws IOException {
 		try {
 			Args args = Args.parse(rawArgs);
+
+			// print version and exit if --version option present.
+			if (args.hasVersion()) {
+				printVersion();
+				return;
+			}
+
 			validate(args);
 			startup(args);
 		} catch (ParseException e) {
@@ -151,5 +158,10 @@ public class CryptomatorCli {
 		} catch (Exception e) {
 			LOG.error("Main thread blocking failed.");
 		}
+	}
+
+	private static void printVersion() {
+		String version = Version.IMPLEMENTATION_VERSION;
+		System.out.println(version);
 	}
 }

--- a/src/main/java/org/cryptomator/cli/Version.java
+++ b/src/main/java/org/cryptomator/cli/Version.java
@@ -4,8 +4,7 @@ public class Version {
     public static final String IMPLEMENTATION_VERSION = getImplementationVersion();
 
     private static String getImplementationVersion() {
-        return new Version()
-                .getClass()
+        return Version.class
                 .getPackage()
                 .getImplementationVersion();
     }

--- a/src/main/java/org/cryptomator/cli/Version.java
+++ b/src/main/java/org/cryptomator/cli/Version.java
@@ -1,0 +1,12 @@
+package org.cryptomator.cli;
+
+public class Version {
+    public static final String IMPLEMENTATION_VERSION = getImplementationVersion();
+
+    private static String getImplementationVersion() {
+        return new Version()
+                .getClass()
+                .getPackage()
+                .getImplementationVersion();
+    }
+}


### PR DESCRIPTION
Resolves #37
Resolves #50

I have added the option to print the version and exit if the `--version` option is given.
The printed version is the `<Implementation-Version>` specified in the [pom.xml](https://github.com/APengue1/cryptomator-cli/blob/develop/pom.xml#L110).

For example:
``` bash
$ java -jar cryptomator-cli.jar --version
0.6.0-SNAPSHOT
```
Let me know what you think and if you have any suggestions for the proposed changes ! :)