### PR TITLE
Feature: Split CI builds into different workflows

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -135,7 +135,6 @@ jobs:
           path: ./target/cryptomator-cli${{ matrix.binary-dir-suffix }}
           if-no-files-found: error
       - name: Zip binary for release
-        if: startsWith(github.ref, 'refs/tags/') && github.event.action == 'published'
         run: zip -r ./target/cryptomator-cli${{ matrix.binary-dir-suffix }} ./cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}.zip
       - name: Create detached GPG signature with key 615D449FE6E6A235
         run: |

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -33,10 +33,10 @@ jobs:
         shell: pwsh
         run: |
           if ( '${{github.event_name}}' -eq 'release') {
-            echo "version=${{ github.event.release.tag_name}}" >> "$GITHUB_OUTPUT"
+            echo 'version=${{ github.event.release.tag_name}}' >> "$env:GITHUB_OUTPUT"
             exit 0
           } elseif ('${{inputs.sem-version}}') {
-            echo "version=${{ inputs.sem-version}}" >> "$GITHUB_OUTPUT"
+            echo 'version=${{ inputs.sem-version}}' >> "$env:GITHUB_OUTPUT"
             exit 0
           }
           Write-Error "Version neither via input nor by tag specified. Aborting"

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -131,7 +131,7 @@ jobs:
           ${JPACKAGE_OS_OPTS}
       - uses: actions/upload-artifact@v4
         with:
-          name: cryptomator-cli-${{matrix.suffix}}
+          name: cryptomator-cli-${{matrix.suffix}}-${{matrix.architecture}}
           path: ./target/cryptomator-cli${{ matrix.binary-dir-suffix }}
           if-no-files-found: error
       - name: Zip binary for release

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -54,22 +54,27 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            suffix: linux
             architecture: x64
             native-access-lib: 'org.cryptomator.jfuse.linux.amd64'
             binary-dir-suffix: ""
           - os: [self-hosted, Linux, ARM64]
+            suffix: linux
             architecture: aarch64
             native-access-lib: 'org.cryptomator.jfuse.linux.aarch64'
             binary-dir-suffix: ""
           - os: macos-latest-large
+            suffix: mac
             architecture: x64
             native-access-lib: 'org.cryptomator.jfuse.mac'
             binary-dir-suffix: ".app"
           - os: macos-latest
+            suffix: mac
             architecture: aarch64
             native-access-lib: 'org.cryptomator.jfuse.mac'
             binary-dir-suffix: ".app"
           - os: windows-latest
+            suffix: win
             architecture: x64
             native-access-lib: 'org.cryptomator.jfuse.win'
             binary-dir-suffix: ""
@@ -126,6 +131,7 @@ jobs:
           ${JPACKAGE_OS_OPTS}
       - uses: actions/upload-artifact@v4
         with:
+          name: cryptomator-cli-${{matrix.suffix}}
           path: ./target/cryptomator-cli${{ matrix.binary-dir-suffix }}
           if-no-files-found: error
       - name: Zip binary for release
@@ -145,6 +151,6 @@ jobs:
           fail_on_unmatched_files: true
           token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}
           files: |
-            cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}.zip
+            cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}-${{matrix.suffix}}-${{matrix.architecture}}.zip
             cryptomator-cli-*.asc
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -97,11 +97,11 @@ jobs:
           --verbose
           --output target/runtime
           --module-path "${JAVA_HOME}/jmods"
-          --add-modules java.base,java.compiler,java.naming,java.xml `
-          --strip-native-commands `
-          --no-header-files `
-          --no-man-pages `
-          --strip-debug `
+          --add-modules java.base,java.compiler,java.naming,java.xml
+          --strip-native-commands
+          --no-header-files
+          --no-man-pages
+          --strip-debug
           --compress zip-6
       - name: Run jpackage
         run: >

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -71,14 +71,14 @@ jobs:
       - name: Set version
         run: mvn versions:set -DnewVersion=${{ needs.prepare.outputs.semVerStr }}
       - name: Run maven
-        run: mvn -B clean package -Pwin -DskipTests
+        run: mvn -B clean package -DskipTests
       - name: Patch target dir
         run: |
           cp LICENSE.txt target
           cp target/cryptomator-*.jar target/mods
       - name: Run jlink
         run: >
-          ${JAVA_HOME}/bin/jlink
+          "${JAVA_HOME}/bin/jlink"
           --verbose
           --output target/runtime
           --module-path "${JAVA_HOME}/jmods"
@@ -90,7 +90,7 @@ jobs:
           --compress zip-6
       - name: Run jpackage
         run: >
-          ${JAVA_HOME}/bin/jpackage
+          "${JAVA_HOME}/bin/jpackage"
           --verbose
           --type app-image
           --runtime-image target/runtime
@@ -103,7 +103,6 @@ jobs:
           --copyright "(C) 2016 - 2024 Skymatic GmbH"
           --app-version "${{ needs.prepare.outputs.semVerNum }}"
           --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
-          --java-options "--enable-preview"
           --java-options "--enable-native-access=${{ matrix.native-access-lib }}"
           --java-options "-Xss5m"
           --java-options "-Xmx256m"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,134 @@
+name: Java app image Linux
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      sem-version:
+        description: 'Version'
+        required: false
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  JAVA_DIST: 'zulu'
+  JAVA_VERSION: '22.0.2+9'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    name: Determines the versions strings for the binaries
+    runs-on: [ubuntu-latest]
+    outputs:
+      semVerStr: ${{ steps.determine-version.outputs.version }}
+      semVerNum: ${{steps.determine-number.outputs.number}}
+    steps:
+      - id: determine-version
+        shell: pwsh
+        run: |
+          if ( '${{github.event_name}}' -eq 'release') {
+            echo 'version=${{ github.event.release.tag_name}}' >> "$env:GITHUB_OUTPUT"
+            exit 0
+          } elseif ('${{inputs.sem-version}}') {
+            echo 'version=${{ inputs.sem-version}}' >> "$env:GITHUB_OUTPUT"
+            exit 0
+          }
+          Write-Error "Version neither via input nor by tag specified. Aborting"
+          exit 1
+      - id: determine-number
+        run: |
+          SEM_VER_NUM=$(echo "${{ steps.determine-version.outputs.version }}" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          echo "number=${SEM_VER_NUM}" >> "$GITHUB_OUTPUT"
+
+  build-binary:
+    name: Build java app image
+    needs: [prepare]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            architecture: x64
+            native-access-lib: 'org.cryptomator.jfuse.linux.amd64'
+            artifact-name: cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}-linux-x64.zip
+          - os: [self-hosted, Linux, ARM64]
+            architecture: aarch64
+            native-access-lib: 'org.cryptomator.jfuse.linux.aarch64'
+            artifact-name: cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}-linux-aarch64.zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DIST }}
+      - name: Set version
+        run: mvn versions:set -DnewVersion=${{ needs.prepare.outputs.semVerStr }}
+      - name: Run maven
+        run: mvn -B clean package -Pwin -DskipTests
+      - name: Patch target dir
+        run: |
+          cp LICENSE.txt target
+          cp target/cryptomator-*.jar target/mods
+      - name: Run jlink
+        run: >
+          ${JAVA_HOME}/bin/jlink
+          --verbose
+          --output target/runtime
+          --module-path "${JAVA_HOME}/jmods"
+          --add-modules java.base,java.compiler,java.naming,java.xml
+          --strip-native-commands
+          --no-header-files
+          --no-man-pages
+          --strip-debug
+          --compress zip-6
+      - name: Run jpackage
+        run: >
+          ${JAVA_HOME}/bin/jpackage
+          --verbose
+          --type app-image
+          --runtime-image target/runtime
+          --input target/libs
+          --module-path target/mods
+          --module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli
+          --dest target
+          --name cryptomator-cli
+          --vendor "Skymatic GmbH"
+          --copyright "(C) 2016 - 2024 Skymatic GmbH"
+          --app-version "${{ needs.prepare.outputs.semVerNum }}"
+          --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
+          --java-options "--enable-preview"
+          --java-options "--enable-native-access=${{ matrix.native-access-lib }}"
+          --java-options "-Xss5m"
+          --java-options "-Xmx256m"
+          --java-options "-Dfile.encoding=\"utf-8\""
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cryptomator-cli-linux-${{ matrix.architecture }}
+          path: ./target/cryptomator-cli
+          if-no-files-found: error
+      - name: Zip binary for release
+        run: zip -r ./${{ matrix.artifact-name}} ./target/cryptomator-cli
+      - name: Create detached GPG signature with key 615D449FE6E6A235
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a ./${{ matrix.artifact-name }}
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
+      - name: Publish artefact on GitHub Releases
+        if: startsWith(github.ref, 'refs/tags/') && github.event.action == 'published'
+        uses: softprops/action-gh-release@v2
+        with:
+          fail_on_unmatched_files: true
+          token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}
+          files: |
+            ${{ matrix.artifact-name }}
+            cryptomator-cli-*.asc
+

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,4 +1,4 @@
-name: Build java app image
+name: Java app image macOS
 
 on:
   release:
@@ -53,41 +53,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            suffix: linux
-            architecture: x64
-            native-access-lib: 'org.cryptomator.jfuse.linux.amd64'
-            binary-dir-suffix: ""
-          - os: [self-hosted, Linux, ARM64]
-            suffix: linux
-            architecture: aarch64
-            native-access-lib: 'org.cryptomator.jfuse.linux.aarch64'
-            binary-dir-suffix: ""
-          - os: macos-latest-large
-            suffix: mac
-            architecture: x64
-            native-access-lib: 'org.cryptomator.jfuse.mac'
-            binary-dir-suffix: ".app"
           - os: macos-latest
-            suffix: mac
-            architecture: aarch64
-            native-access-lib: 'org.cryptomator.jfuse.mac'
-            binary-dir-suffix: ".app"
-          - os: windows-latest
-            suffix: win
+            architecture: arm64
+            artifact-name: cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}-mac-arm64.zip
+          - os: macos-13
             architecture: x64
-            native-access-lib: 'org.cryptomator.jfuse.win'
-            binary-dir-suffix: ""
+            artifact-name: cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}-mac-x64.zip
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Preparations for windows runner
-        if: startsWith(matrix.os, 'windows')
-        run: echo "JPACKAGE_OS_OPTS=--win-console" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '22'
-          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DIST }}
       - name: Set version
         run: mvn versions:set -DnewVersion=${{ needs.prepare.outputs.semVerStr }}
       - name: Run maven
@@ -124,22 +102,23 @@ jobs:
           --app-version "${{ needs.prepare.outputs.semVerNum }}"
           --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
           --java-options "--enable-preview"
-          --java-options "--enable-native-access=${{ matrix.native-access-lib }}"
+          --java-options "--enable-native-access=org.cryptomator.jfuse.mac"
           --java-options "-Xss5m"
           --java-options "-Xmx256m"
           --java-options "-Dfile.encoding=\"utf-8\""
-          ${JPACKAGE_OS_OPTS}
       - uses: actions/upload-artifact@v4
         with:
-          name: cryptomator-cli-${{matrix.suffix}}-${{matrix.architecture}}
-          path: ./target/cryptomator-cli${{ matrix.binary-dir-suffix }}
+          name: cryptomator-cli-mac-${{ matrix.architecture }}
+          path: ./target/cryptomator-cli.app
           if-no-files-found: error
+      - name: TODO sign binaries
+        run: echo "TODO sign it and notarize it"
       - name: Zip binary for release
-        run: zip -r ./target/cryptomator-cli${{ matrix.binary-dir-suffix }} ./cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}.zip
+        run: zip -r ./${{ matrix.artifact-name}} ./target/cryptomator-cli.app
       - name: Create detached GPG signature with key 615D449FE6E6A235
         run: |
           echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
-          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a ./cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}.zip
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a ./${{ matrix.artifact-name }}
         env:
           GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
@@ -150,6 +129,6 @@ jobs:
           fail_on_unmatched_files: true
           token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}
           files: |
-            cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}-${{matrix.suffix}}-${{matrix.architecture}}.zip
+            ${{ matrix.artifact-name }}
             cryptomator-cli-*.asc
 

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -69,14 +69,14 @@ jobs:
       - name: Set version
         run: mvn versions:set -DnewVersion=${{ needs.prepare.outputs.semVerStr }}
       - name: Run maven
-        run: mvn -B clean package -Pwin -DskipTests
+        run: mvn -B clean package -DskipTests
       - name: Patch target dir
         run: |
           cp LICENSE.txt target
           cp target/cryptomator-*.jar target/mods
       - name: Run jlink
         run: >
-          ${JAVA_HOME}/bin/jlink
+          "${JAVA_HOME}/bin/jlink"
           --verbose
           --output target/runtime
           --module-path "${JAVA_HOME}/jmods"
@@ -88,7 +88,7 @@ jobs:
           --compress zip-6
       - name: Run jpackage
         run: >
-          ${JAVA_HOME}/bin/jpackage
+          "${JAVA_HOME}/bin/jpackage"
           --verbose
           --type app-image
           --runtime-image target/runtime
@@ -101,7 +101,6 @@ jobs:
           --copyright "(C) 2016 - 2024 Skymatic GmbH"
           --app-version "${{ needs.prepare.outputs.semVerNum }}"
           --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
-          --java-options "--enable-preview"
           --java-options "--enable-native-access=org.cryptomator.jfuse.mac"
           --java-options "-Xss5m"
           --java-options "-Xmx256m"

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -61,14 +61,14 @@ jobs:
       - name: Set version
         run: mvn versions:set -DnewVersion=${{ needs.prepare.outputs.semVerStr }}
       - name: Run maven
-        run: mvn -B clean package -Pwin -DskipTests
+        run: mvn -B clean package -DskipTests
       - name: Patch target dir
         run: |
           cp LICENSE.txt target
           cp target/cryptomator-*.jar target/mods
       - name: Run jlink
         run: >
-          ${JAVA_HOME}/bin/jlink
+          "${JAVA_HOME}/bin/jlink"
           --verbose
           --output target/runtime
           --module-path "${JAVA_HOME}/jmods"
@@ -80,7 +80,7 @@ jobs:
           --compress zip-6
       - name: Run jpackage
         run: >
-          ${JAVA_HOME}/bin/jpackage
+          "${JAVA_HOME}/bin/jpackage"
           --verbose
           --type app-image
           --runtime-image target/runtime
@@ -93,7 +93,6 @@ jobs:
           --copyright "(C) 2016 - 2024 Skymatic GmbH"
           --app-version "${{ needs.prepare.outputs.semVerNum }}"
           --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
-          --java-options "--enable-preview"
           --java-options "--enable-native-access=org.cryptomator.jfuse.win"
           --java-options "-Xss5m"
           --java-options "-Xmx256m"
@@ -105,8 +104,7 @@ jobs:
           path: ./target/cryptomator-cli
           if-no-files-found: error
       - name: TODO Sign binaries
-        run: echo TODO; exit 1;
-        #TODO
+        run: echo TODO
       - name: Zip binary for release
         shell: pwsh
         run: Compress-Archive -Path .\target\cryptomator-cli -DestinationPath .\${{ env.artifact-name}}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -1,0 +1,129 @@
+name: Java app image Windows
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      sem-version:
+        description: 'Version'
+        required: false
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  JAVA_DIST: 'zulu'
+  JAVA_VERSION: '22.0.2+9'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    name: Determines the versions strings for the binaries
+    runs-on: [ubuntu-latest]
+    outputs:
+      semVerStr: ${{ steps.determine-version.outputs.version }}
+      semVerNum: ${{steps.determine-number.outputs.number}}
+    steps:
+      - id: determine-version
+        shell: pwsh
+        run: |
+          if ( '${{github.event_name}}' -eq 'release') {
+            echo 'version=${{ github.event.release.tag_name}}' >> "$env:GITHUB_OUTPUT"
+            exit 0
+          } elseif ('${{inputs.sem-version}}') {
+            echo 'version=${{ inputs.sem-version}}' >> "$env:GITHUB_OUTPUT"
+            exit 0
+          }
+          Write-Error "Version neither via input nor by tag specified. Aborting"
+          exit 1
+      - id: determine-number
+        run: |
+          SEM_VER_NUM=$(echo "${{ steps.determine-version.outputs.version }}" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          echo "number=${SEM_VER_NUM}" >> "$GITHUB_OUTPUT"
+
+  build-binary:
+    name: Build java app image
+    needs: [prepare]
+    runs-on: windows-latest
+    env:
+        artifact-name: cryptomator-cli-${{ needs.prepare.outputs.semVerStr }}-win-x64.zip
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DIST }}
+      - name: Set version
+        run: mvn versions:set -DnewVersion=${{ needs.prepare.outputs.semVerStr }}
+      - name: Run maven
+        run: mvn -B clean package -Pwin -DskipTests
+      - name: Patch target dir
+        run: |
+          cp LICENSE.txt target
+          cp target/cryptomator-*.jar target/mods
+      - name: Run jlink
+        run: >
+          ${JAVA_HOME}/bin/jlink
+          --verbose
+          --output target/runtime
+          --module-path "${JAVA_HOME}/jmods"
+          --add-modules java.base,java.compiler,java.naming,java.xml
+          --strip-native-commands
+          --no-header-files
+          --no-man-pages
+          --strip-debug
+          --compress zip-6
+      - name: Run jpackage
+        run: >
+          ${JAVA_HOME}/bin/jpackage
+          --verbose
+          --type app-image
+          --runtime-image target/runtime
+          --input target/libs
+          --module-path target/mods
+          --module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli
+          --dest target
+          --name cryptomator-cli
+          --vendor "Skymatic GmbH"
+          --copyright "(C) 2016 - 2024 Skymatic GmbH"
+          --app-version "${{ needs.prepare.outputs.semVerNum }}"
+          --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
+          --java-options "--enable-preview"
+          --java-options "--enable-native-access=org.cryptomator.jfuse.win"
+          --java-options "-Xss5m"
+          --java-options "-Xmx256m"
+          --java-options "-Dfile.encoding=\"utf-8\""
+          --win-console
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cryptomator-cli-win-x64
+          path: ./target/cryptomator-cli
+          if-no-files-found: error
+      - name: TODO Sign binaries
+        run: echo TODO; exit 1;
+        #TODO
+      - name: Zip binary for release
+        shell: pwsh
+        run: Compress-Archive -Path .\target\cryptomator-cli -DestinationPath .\${{ env.artifact-name}}
+      - name: Create detached GPG signature with key 615D449FE6E6A235
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a ./${{ env.artifact-name}}
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
+      - name: Publish artefact on GitHub Releases
+        if: startsWith(github.ref, 'refs/tags/') && github.event.action == 'published'
+        uses: softprops/action-gh-release@v2
+        with:
+          fail_on_unmatched_files: true
+          token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}
+          files: |
+            ${{ env.artifact-name}}
+            cryptomator-cli-*.asc
+


### PR DESCRIPTION
This PR splits the CI binary/release builds into different workflow files.

The different OSs share a good amount of code, but on the other hand each has its peculiarities. Also Windows and macOS artifacts should be signed (not part of this PR).