### PR TITLE
Feature: Use argument files

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run jpackage
         run: |
           envsubst < dist/jpackage.args > target/jpackage.args
-          "${JAVA_HOME}/bin/jpackage" '@./target/jpackage.args' --win-console
+          "${JAVA_HOME}/bin/jpackage" '@./target/jpackage.args'
         env:
           JP_APP_VERSION: ${{ needs.prepare.outputs.semVerNum }}
           APP_VERSION: ${{ needs.prepare.outputs.semVerStr }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -77,36 +77,17 @@ jobs:
           cp LICENSE.txt target
           cp target/cryptomator-*.jar target/mods
       - name: Run jlink
-        run: >
-          "${JAVA_HOME}/bin/jlink"
-          --verbose
-          --output target/runtime
-          --module-path "${JAVA_HOME}/jmods"
-          --add-modules java.base,java.compiler,java.naming,java.xml
-          --strip-native-commands
-          --no-header-files
-          --no-man-pages
-          --strip-debug
-          --compress zip-6
+        run: |
+          envsubst < dist/jlink.args > target/jlink.args
+          "${JAVA_HOME}/bin/jlink" '@./target/jlink.args'
       - name: Run jpackage
-        run: >
-          "${JAVA_HOME}/bin/jpackage"
-          --verbose
-          --type app-image
-          --runtime-image target/runtime
-          --input target/libs
-          --module-path target/mods
-          --module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli
-          --dest target
-          --name cryptomator-cli
-          --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2024 Skymatic GmbH"
-          --app-version "${{ needs.prepare.outputs.semVerNum }}"
-          --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
-          --java-options "--enable-native-access=${{ matrix.native-access-lib }}"
-          --java-options "-Xss5m"
-          --java-options "-Xmx256m"
-          --java-options "-Dfile.encoding=\"utf-8\""
+        run: |
+          envsubst < dist/jpackage.args > target/jpackage.args
+          "${JAVA_HOME}/bin/jpackage" '@./target/jpackage.args' --win-console
+        env:
+          JP_APP_VERSION: ${{ needs.prepare.outputs.semVerNum }}
+          APP_VERSION: ${{ needs.prepare.outputs.semVerStr }}
+          NATIVE_ACCESS_PACKAGE: ${{ matrix.native-access-lib }}
       - uses: actions/upload-artifact@v4
         with:
           name: cryptomator-cli-linux-${{ matrix.architecture }}

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Run jpackage
         run: |
           envsubst < dist/jpackage.args > target/jpackage.args
-          "${JAVA_HOME}/bin/jpackage" '@./target/jpackage.args' --win-console
+          "${JAVA_HOME}/bin/jpackage" '@./target/jpackage.args'
         env:
           JP_APP_VERSION: ${{ needs.prepare.outputs.semVerNum }}
           APP_VERSION: ${{ needs.prepare.outputs.semVerStr }}

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -75,36 +75,17 @@ jobs:
           cp LICENSE.txt target
           cp target/cryptomator-*.jar target/mods
       - name: Run jlink
-        run: >
-          "${JAVA_HOME}/bin/jlink"
-          --verbose
-          --output target/runtime
-          --module-path "${JAVA_HOME}/jmods"
-          --add-modules java.base,java.compiler,java.naming,java.xml
-          --strip-native-commands
-          --no-header-files
-          --no-man-pages
-          --strip-debug
-          --compress zip-6
+        run: |
+          envsubst < dist/jlink.args > target/jlink.args
+          "${JAVA_HOME}/bin/jlink" '@./target/jlink.args'
       - name: Run jpackage
-        run: >
-          "${JAVA_HOME}/bin/jpackage"
-          --verbose
-          --type app-image
-          --runtime-image target/runtime
-          --input target/libs
-          --module-path target/mods
-          --module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli
-          --dest target
-          --name cryptomator-cli
-          --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2024 Skymatic GmbH"
-          --app-version "${{ needs.prepare.outputs.semVerNum }}"
-          --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
-          --java-options "--enable-native-access=org.cryptomator.jfuse.mac"
-          --java-options "-Xss5m"
-          --java-options "-Xmx256m"
-          --java-options "-Dfile.encoding=\"utf-8\""
+        run: |
+          envsubst < dist/jpackage.args > target/jpackage.args
+          "${JAVA_HOME}/bin/jpackage" '@./target/jpackage.args' --win-console
+        env:
+          JP_APP_VERSION: ${{ needs.prepare.outputs.semVerNum }}
+          APP_VERSION: ${{ needs.prepare.outputs.semVerStr }}
+          NATIVE_ACCESS_PACKAGE: org.cryptomator.jfuse.mac
       - uses: actions/upload-artifact@v4
         with:
           name: cryptomator-cli-mac-${{ matrix.architecture }}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -67,37 +67,17 @@ jobs:
           cp LICENSE.txt target
           cp target/cryptomator-*.jar target/mods
       - name: Run jlink
-        run: >
-          "${JAVA_HOME}/bin/jlink"
-          --verbose
-          --output target/runtime
-          --module-path "${JAVA_HOME}/jmods"
-          --add-modules java.base,java.compiler,java.naming,java.xml
-          --strip-native-commands
-          --no-header-files
-          --no-man-pages
-          --strip-debug
-          --compress zip-6
+        run: |
+          envsubst < dist/jlink.args > target/jlink.args
+          "${JAVA_HOME}/bin/jlink" '@./target/jlink.args'
       - name: Run jpackage
-        run: >
-          "${JAVA_HOME}/bin/jpackage"
-          --verbose
-          --type app-image
-          --runtime-image target/runtime
-          --input target/libs
-          --module-path target/mods
-          --module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli
-          --dest target
-          --name cryptomator-cli
-          --vendor "Skymatic GmbH"
-          --copyright "(C) 2016 - 2024 Skymatic GmbH"
-          --app-version "${{ needs.prepare.outputs.semVerNum }}"
-          --java-options "-Dorg.cryptomator.cli.version=${{ needs.prepare.outputs.semVerStr }}"
-          --java-options "--enable-native-access=org.cryptomator.jfuse.win"
-          --java-options "-Xss5m"
-          --java-options "-Xmx256m"
-          --java-options "-Dfile.encoding=\"utf-8\""
-          --win-console
+        run: |
+          envsubst < dist/jpackage.args > target/jpackage.args
+          "${JAVA_HOME}/bin/jpackage" '@./target/jpackage.args' --win-console
+        env:
+          JP_APP_VERSION: ${{ needs.prepare.outputs.semVerNum }}
+          APP_VERSION: ${{ needs.prepare.outputs.semVerStr }}
+          NATIVE_ACCESS_PACKAGE: org.cryptomator.jfuse.win
       - uses: actions/upload-artifact@v4
         with:
           name: cryptomator-cli-win-x64

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 echo "Building cryptomator cli..."
 
-APP_VERSION='0.1.0-local'
+export APP_VERSION='0.1.0-local'
 
 # Check if Maven is installed
 if ! command -v mvn &> /dev/null; then
@@ -39,7 +39,7 @@ if [ $? -ne 0 ] || [ ! -d ./target/runtime ]; then
     exit 1
 fi
 
-NATIVE_ACCESS_PACKAGE="no.native.access.available"
+export NATIVE_ACCESS_PACKAGE="no.native.access.available"
 _OS=$(uname -s)
 if (echo "$_OS" | grep -q "Linux.*") ; then
     _ARCH=$(uname -m)
@@ -53,7 +53,7 @@ if (echo "$_OS" | grep -q "Linux.*") ; then
     fi
 fi
 
-JP_APP_VERSION='99.9.9'
+export JP_APP_VERSION='99.9.9'
 envsubst < dist/jpackage.args > target/jpackage.args
 
 echo "Creating app binary with jpackage..."

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -61,23 +61,8 @@ fi
 
 echo "Creating app binary with jpackage..."
 "$JAVA_HOME/bin/jpackage" \
-    --verbose \
-    --type app-image \
-    --runtime-image target/runtime \
-    --input target/libs \
-    --module-path target/mods \
-    --module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli \
-    --dest target \
-    --name cryptomator-cli \
-    --vendor "Skymatic GmbH" \
-    --copyright "(C) 2016 - 2024 Skymatic GmbH" \
-    --app-version "0.0.1.0" \
-    --java-options "-Dorg.cryptomator.cli.version=0.0.1-local" \
-    --java-options "--enable-preview" \
-    --java-options "--enable-native-access=${NATIVE_ACCESS_PACKAGE}" \
-    --java-options "-Xss5m" \
-    --java-options "-Xmx256m" \
-    --java-options "-Dfile.encoding=utf-8" \
+    '@./dist/jpackage.args' \
+    --java-options "--enable-native-access=${NATIVE_ACCESS_PACKAGE}"
 
 if [ $? -ne 0 ] || [ ! -d ./target/cryptomator-cli ]; then
     echo "Binary creation with jpackage failed."

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -31,9 +31,8 @@ cp ./LICENSE.txt ./target/
 mv ./target/cryptomator-cli-*.jar ./target/mods
 
 echo "Creating JRE with jlink..."
-"$JAVA_HOME/bin/jlink" \
-    '@./dist/jlink.args' \
-    --module-path "${JAVA_HOME}/jmods"
+envsubst < dist/jlink.args > target/jlink.args
+"$JAVA_HOME/bin/jlink" '@./target/jlink.args'
 
 if [ $? -ne 0 ] || [ ! -d ./target/runtime ]; then
     echo "JRE creation with jlink failed."

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -3,6 +3,8 @@ set -euxo pipefail
 
 echo "Building cryptomator cli..."
 
+APP_VERSION='0.1.0-local'
+
 # Check if Maven is installed
 if ! command -v mvn &> /dev/null; then
     echo "Maven is not installed. Please install Maven to proceed."
@@ -52,10 +54,11 @@ if (echo "$_OS" | grep -q "Linux.*") ; then
     fi
 fi
 
+JP_APP_VERSION='99.9.9'
+envsubst < dist/jpackage.args > target/jpackage.args
+
 echo "Creating app binary with jpackage..."
-"$JAVA_HOME/bin/jpackage" \
-    '@./dist/jpackage.args' \
-    --java-options "--enable-native-access=${NATIVE_ACCESS_PACKAGE}"
+"$JAVA_HOME/bin/jpackage" '@./target/jpackage.args'
 
 if [ $? -ne 0 ] || [ ! -d ./target/cryptomator-cli ]; then
     echo "Binary creation with jpackage failed."

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -30,15 +30,8 @@ mv ./target/cryptomator-cli-*.jar ./target/mods
 
 echo "Creating JRE with jlink..."
 "$JAVA_HOME/bin/jlink" \
-    --verbose \
-    --output target/runtime \
-    --module-path "${JAVA_HOME}/jmods" \
-    --add-modules java.base,java.compiler,java.naming,java.xml \
-    --strip-native-commands \
-    --no-header-files \
-    --no-man-pages \
-    --strip-debug \
-    --compress zip-0
+    '@./dist/jlink.args' \
+    --module-path "${JAVA_HOME}/jmods"
 
 if [ $? -ne 0 ] || [ ! -d ./target/runtime ]; then
     echo "JRE creation with jlink failed."

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -29,15 +29,8 @@ mv ./target/cryptomator-cli-*.jar ./target/mods
 
 echo "Creating JRE with jlink..."
 "$JAVA_HOME/bin/jlink" \
-    --verbose \
-    --output target/runtime \
-    --module-path "${JAVA_HOME}/jmods" \
-    --add-modules java.base,java.compiler,java.naming,java.xml \
-    --strip-native-commands \
-    --no-header-files \
-    --no-man-pages \
-    --strip-debug \
-    --compress zip-0
+    '@./dist/jlink.args' \
+    --module-path "${JAVA_HOME}/jmods"
 
 if [ $? -ne 0 ] || [ ! -d ./target/runtime ]; then
     echo "JRE creation with jlink failed."

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -2,7 +2,7 @@
 
 echo "Building cryptomator cli..."
 
-APP_VERSION='0.1.0-local'
+export APP_VERSION='0.1.0-local'
 
 # Check if Maven is installed
 if ! command -v mvn &> /dev/null; then
@@ -38,7 +38,8 @@ if [ $? -ne 0 ] || [ ! -d ./target/runtime ]; then
     exit 1
 fi
 
-JP_APP_VERSION='99.9.9'
+export JP_APP_VERSION='99.9.9'
+export NATIVE_ACCESS_PACKAGE="org.cryptomator.jfuse.mac"
 envsubst < dist/jpackage.args > target/jpackage.args
 
 echo "Creating app binary with jpackage..."

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -2,6 +2,8 @@
 
 echo "Building cryptomator cli..."
 
+APP_VERSION='0.1.0-local'
+
 # Check if Maven is installed
 if ! command -v mvn &> /dev/null; then
     echo "Maven is not installed. Please install Maven to proceed."
@@ -37,10 +39,11 @@ if [ $? -ne 0 ] || [ ! -d ./target/runtime ]; then
     exit 1
 fi
 
+JP_APP_VERSION='99.9.9'
+envsubst < dist/jpackage.args > target/jpackage.args
+
 echo "Creating app binary with jpackage..."
-"$JAVA_HOME/bin/jpackage" \
-    '@./dist/jpackage.args' \
-    --java-options "--enable-native-access=org.cryptomator.jfuse.mac"
+"$JAVA_HOME/bin/jpackage" '@./target/jpackage.args'
 
 if [ $? -ne 0 ] || [ ! -d ./target/cryptomator-cli.app ]; then
     echo "Binary creation with jpackage failed."

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -30,9 +30,8 @@ cp ./LICENSE.txt ./target/
 mv ./target/cryptomator-cli-*.jar ./target/mods
 
 echo "Creating JRE with jlink..."
-"$JAVA_HOME/bin/jlink" \
-    '@./dist/jlink.args' \
-    --module-path "${JAVA_HOME}/jmods"
+envsubst < dist/jlink.args > target/jlink.args
+"$JAVA_HOME/bin/jlink" '@./target/jlink.args'
 
 if [ $? -ne 0 ] || [ ! -d ./target/runtime ]; then
     echo "JRE creation with jlink failed."

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -46,23 +46,8 @@ fi
 
 echo "Creating app binary with jpackage..."
 "$JAVA_HOME/bin/jpackage" \
-    --verbose \
-    --type app-image \
-    --runtime-image target/runtime \
-    --input target/libs \
-    --module-path target/mods \
-    --module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli \
-    --dest target \
-    --name cryptomator-cli \
-    --vendor "Skymatic GmbH" \
-    --copyright "(C) 2016 - 2024 Skymatic GmbH" \
-    --app-version "99.9.9" \
-    --java-options "-Dorg.cryptomator.cli.version=0.0.1-local" \
-    --java-options "--enable-preview" \
-    --java-options "--enable-native-access=org.cryptomator.jfuse.mac" \
-    --java-options "-Xss5m" \
-    --java-options "-Xmx256m" \
-    --java-options "-Dfile.encoding=utf-8" \
+    '@./dist/jpackage.args' \
+    --java-options "--enable-native-access=org.cryptomator.jfuse.mac"
 
 if [ $? -ne 0 ] || [ ! -d ./target/cryptomator-cli.app ]; then
     echo "Binary creation with jpackage failed."

--- a/build_win.ps1
+++ b/build_win.ps1
@@ -1,5 +1,7 @@
 "Building cryptomator cli..."
 
+$appVersion='0.1.0-local'
+
 # Check if maven is installed
 $commands = 'mvn'
 foreach ($cmd in $commands) {
@@ -32,13 +34,18 @@ if ( ($LASTEXITCODE -ne 0) -or (-not (Test-Path ./target/runtime))) {
     throw "JRE creation with jLink failed with exit code $LASTEXITCODE."
 }
 
+## powershell does not have envsubst
+$jpAppVersion='99.9.9'
+Get-Content -Path './dist/jpackage.args' | ForEach-Object {
+    $_.Replace('${APP_VERSION}', $appVersion)
+    .Replace('${JP_APP_VERSION}', $jpAppVersion)
+    .Replace('${NATIVE_ACCESS_PACKAGE}', 'org.cryptomator.jfuse.win')
+} | Out-File -FilePath './target/jpackage.args'
+
 # jpackage
 # app-version is hard coded, since the script is only for local test builds
 Write-Host "Creating app binary with jpackage..."
-& $env:JAVA_HOME/bin/jpackage `
-    `@./dist/jpackage.args `
-    --java-options "--enable-native-access=org.cryptomator.jfuse.win" `
-    --win-console
+& $env:JAVA_HOME/bin/jpackage `@./target/jpackage.args --win-console
 
 if ( ($LASTEXITCODE -ne 0) -or (-not (Test-Path ./target/cryptomator-cli))) {
     throw "Binary creation with jpackage failed with exit code $LASTEXITCODE."

--- a/build_win.ps1
+++ b/build_win.ps1
@@ -25,27 +25,20 @@ Move-Item ./target/cryptomator-cli-*.jar ./target/mods -ErrorAction Stop
 
 Write-Host "Creating JRE with jlink..."
 & $env:JAVA_HOME/bin/jlink `
---verbose `
---output target/runtime `
---module-path "${env:JAVA_HOME}/jmods" `
---add-modules java.base,java.compiler,java.naming,java.xml `
---strip-native-commands `
---no-header-files `
---no-man-pages `
---strip-debug `
---compress zip-0
+    `@./dist/jlink.args `
+    --module-path "${env:JAVA_HOME}/jmods"
 
 if ( ($LASTEXITCODE -ne 0) -or (-not (Test-Path ./target/runtime))) {
-   throw "JRE creation with jLink failed with exit code $LASTEXITCODE."
+    throw "JRE creation with jLink failed with exit code $LASTEXITCODE."
 }
 
 # jpackage
 # app-version is hard coded, since the script is only for local test builds
 Write-Host "Creating app binary with jpackage..."
 & $env:JAVA_HOME/bin/jpackage `
-`@./dist/jpackage.args `
---java-options "--enable-native-access=org.cryptomator.jfuse.win" `
---win-console
+    `@./dist/jpackage.args `
+    --java-options "--enable-native-access=org.cryptomator.jfuse.win" `
+    --win-console
 
 if ( ($LASTEXITCODE -ne 0) -or (-not (Test-Path ./target/cryptomator-cli))) {
     throw "Binary creation with jpackage failed with exit code $LASTEXITCODE."

--- a/build_win.ps1
+++ b/build_win.ps1
@@ -26,9 +26,8 @@ Copy-Item ./LICENSE.txt -Destination ./target -ErrorAction Stop
 Move-Item ./target/cryptomator-cli-*.jar ./target/mods -ErrorAction Stop
 
 Write-Host "Creating JRE with jlink..."
-& $env:JAVA_HOME/bin/jlink `
-    `@./dist/jlink.args `
-    --module-path "${env:JAVA_HOME}/jmods"
+Get-Content -Path './dist/jlink.args' | ForEach-Object { $_.Replace('${JAVA_HOME}', "$env:JAVA_HOME")} | Out-File -FilePath './target/jlink.args'
+& $env:JAVA_HOME/bin/jlink `@./target/jlink.args
 
 if ( ($LASTEXITCODE -ne 0) -or (-not (Test-Path ./target/runtime))) {
     throw "JRE creation with jLink failed with exit code $LASTEXITCODE."
@@ -37,9 +36,9 @@ if ( ($LASTEXITCODE -ne 0) -or (-not (Test-Path ./target/runtime))) {
 ## powershell does not have envsubst
 $jpAppVersion='99.9.9'
 Get-Content -Path './dist/jpackage.args' | ForEach-Object {
-    $_.Replace('${APP_VERSION}', $appVersion)
-    .Replace('${JP_APP_VERSION}', $jpAppVersion)
-    .Replace('${NATIVE_ACCESS_PACKAGE}', 'org.cryptomator.jfuse.win')
+    $_.Replace('${APP_VERSION}', $appVersion).
+        Replace('${JP_APP_VERSION}', $jpAppVersion).
+        Replace('${NATIVE_ACCESS_PACKAGE}', 'org.cryptomator.jfuse.win')
 } | Out-File -FilePath './target/jpackage.args'
 
 # jpackage

--- a/build_win.ps1
+++ b/build_win.ps1
@@ -14,7 +14,7 @@ if(-not $env:JAVA_HOME) {
 # Check Java version
 $minJavaVersion=$(mvn help:evaluate "-Dexpression=jdk.version" -q -DforceStdout)
 $javaVersion = $(& "$env:JAVA_HOME\bin\java" --version) -split ' ' | Select-Object -Index 1
-if( ($javaVersion -split '.' | Select-Object -First 1) -ne "22") {
+if( ($javaVersion.Split('.') | Select-Object -First 1) -ne "22") {
     throw "Java version $javaVersion is too old. Minimum required version is $minJavaVersion"
 }
 
@@ -43,24 +43,9 @@ if ( ($LASTEXITCODE -ne 0) -or (-not (Test-Path ./target/runtime))) {
 # app-version is hard coded, since the script is only for local test builds
 Write-Host "Creating app binary with jpackage..."
 & $env:JAVA_HOME/bin/jpackage `
-    --verbose `
-    --type app-image `
-    --runtime-image target/runtime `
-    --input target/libs `
-    --module-path target/mods `
-    --module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli `
-    --dest target `
-    --name cryptomator-cli `
-    --vendor "Skymatic GmbH" `
-    --copyright "(C) 2016 - 2024 Skymatic GmbH" `
-    --app-version "0.0.1.0" `
-    --java-options "-Dorg.cryptomator.cli.version=0.0.1-local" `
-    --java-options "--enable-preview" `
-    --java-options "--enable-native-access=org.cryptomator.jfuse.win" `
-    --java-options "-Xss5m" `
-    --java-options "-Xmx256m" `
-    --java-options '-Dfile.encoding="utf-8"' `
-    --win-console
+`@./dist/jpackage.args `
+--java-options "--enable-native-access=org.cryptomator.jfuse.win" `
+--win-console
 
 if ( ($LASTEXITCODE -ne 0) -or (-not (Test-Path ./target/cryptomator-cli))) {
     throw "Binary creation with jpackage failed with exit code $LASTEXITCODE."

--- a/dist/jlink.args
+++ b/dist/jlink.args
@@ -1,0 +1,8 @@
+--verbose
+--output target/runtime
+--add-modules java.base,java.compiler,java.naming,java.xml
+--strip-native-commands
+--no-header-files
+--no-man-pages
+--strip-debug
+--compress zip-6

--- a/dist/jlink.args
+++ b/dist/jlink.args
@@ -1,4 +1,5 @@
 --verbose
+--module-path "${JAVA_HOME}/jmods"
 --output target/runtime
 --add-modules java.base,java.compiler,java.naming,java.xml
 --strip-native-commands

--- a/dist/jpackage.args
+++ b/dist/jpackage.args
@@ -1,0 +1,15 @@
+--verbose
+--type app-image
+--runtime-image target/runtime
+--input target/libs
+--module-path target/mods
+--module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli
+--dest target
+--name cryptomator-cli
+--vendor "Skymatic GmbH"
+--copyright "(C) 2016 - 2024 Skymatic GmbH"
+--app-version "99.9.9"
+--java-options "-Dorg.cryptomator.cli.version=0.1.0-local"
+--java-options "-Xss5m"
+--java-options "-Xmx256m"
+--java-options "-Dfile.encoding=\"utf-8\""

--- a/dist/jpackage.args
+++ b/dist/jpackage.args
@@ -1,3 +1,7 @@
+# Contains three env vars:
+# JP_APP_VERSION: The version needed for jpackage. This version _must_ follow the scheme Y.X.X, where Y >= 1 and X >=0
+# APP_VERSION: The actual, semantic version displayed in the cli app
+# NATIVE_ACCESS_PACKAGE: The java package containing the fuse bindings for the system
 --verbose
 --type app-image
 --runtime-image target/runtime
@@ -8,8 +12,9 @@
 --name cryptomator-cli
 --vendor "Skymatic GmbH"
 --copyright "(C) 2016 - 2024 Skymatic GmbH"
---app-version "99.9.9"
---java-options "-Dorg.cryptomator.cli.version=0.1.0-local"
+--app-version "${JP_APP_VERSION}"
+--java-options "-Dorg.cryptomator.cli.version=${APP_VERSION}"
+--java-options "--enable-native-access=${NATIVE_ACCESS_PACKAGE}"
 --java-options "-Xss5m"
 --java-options "-Xmx256m"
 --java-options "-Dfile.encoding=\"utf-8\""


### PR DESCRIPTION
This PR adds argument files for the jpackage and jlink command.

Both java tools accept files containing arguments for the tool. Since the different builds share most of the jpackage/jlink arguments, this deduplicates a lot of code and increases maintainability.