### PR TITLE
Feature: Add vault creation command

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -10,6 +10,7 @@ open module org.cryptomator.cli {
     requires org.fusesource.jansi;
     requires ch.qos.logback.core;
     requires ch.qos.logback.classic;
+    requires org.cryptomator.cryptolib;
 
     provides Configurator with LogbackConfigurator;
 }

--- a/src/main/java/org/cryptomator/cli/Create.java
+++ b/src/main/java/org/cryptomator/cli/Create.java
@@ -72,21 +72,28 @@ public class Create implements Callable<Integer> {
         try (var passphraseContainer = passwordSource.readPassphrase();
                 var masterkey = Masterkey.generate(csprng)) {
 
-            Path masterkeyFilePath = path.resolve(MASTERKEY_FILE_NAME);
-            MasterkeyFileAccess masterkeyFileAccess = new MasterkeyFileAccess(PEPPER, csprng);
-            masterkeyFileAccess.persist(
-                    masterkey, masterkeyFilePath, CharBuffer.wrap(passphraseContainer.content()));
+            persistMasterkey(path, masterkey, passphraseContainer.content());
+            initializeVault(path, masterkey);
+        }
+    }
 
-            try {
-                CryptoFileSystemProperties fsProps =
-                        CryptoFileSystemProperties.cryptoFileSystemProperties()
-                                .withCipherCombo(CryptorProvider.Scheme.SIV_GCM)
-                                .withKeyLoader(ignored -> masterkey.copy())
-                                .build();
-                CryptoFileSystemProvider.initialize(path, fsProps, DEFAULT_KEY_ID);
-            } catch (CryptoException e) {
-                throw new IOException("Vault initialization failed", e);
-            }
+    private void persistMasterkey(Path path, Masterkey masterkey, char[] passphrase)
+            throws IOException {
+        Path masterkeyFilePath = path.resolve(MASTERKEY_FILE_NAME);
+        MasterkeyFileAccess masterkeyFileAccess = new MasterkeyFileAccess(PEPPER, csprng);
+        masterkeyFileAccess.persist(masterkey, masterkeyFilePath, CharBuffer.wrap(passphrase));
+    }
+
+    private void initializeVault(Path path, Masterkey masterkey) throws IOException {
+        CryptoFileSystemProperties fsProps =
+                CryptoFileSystemProperties.cryptoFileSystemProperties()
+                        .withCipherCombo(CryptorProvider.Scheme.SIV_GCM)
+                        .withKeyLoader(ignored -> masterkey.copy())
+                        .build();
+        try {
+            CryptoFileSystemProvider.initialize(path, fsProps, DEFAULT_KEY_ID);
+        } catch (CryptoException e) {
+            throw new IOException("Vault initialization failed", e);
         }
     }
 }

--- a/src/main/java/org/cryptomator/cli/Create.java
+++ b/src/main/java/org/cryptomator/cli/Create.java
@@ -59,22 +59,20 @@ public class Create implements Callable<Integer> {
     public Integer call() throws Exception {
         csprng = SecureRandom.getInstanceStrong();
 
-        createVault(pathToVault);
+        try (var passphraseContainer = passwordSource.readPassphrase()) {
+            passwordSource.confirmPassphrase();
+
+            // Throw exception if there's something already there.
+            Files.createDirectory(pathToVault);
+
+            try (var masterkey = Masterkey.generate(csprng)) {
+                persistMasterkey(pathToVault, masterkey, passphraseContainer.content());
+                initializeVault(pathToVault, masterkey);
+            }
+        }
 
         LOG.info("Vault created successfully in {}", pathToVault);
         return 0;
-    }
-
-    private void createVault(Path path) throws IOException {
-        // Throw exception if there's something already there.
-        Files.createDirectory(path);
-
-        try (var passphraseContainer = passwordSource.readPassphrase();
-                var masterkey = Masterkey.generate(csprng)) {
-
-            persistMasterkey(path, masterkey, passphraseContainer.content());
-            initializeVault(path, masterkey);
-        }
     }
 
     private void persistMasterkey(Path path, Masterkey masterkey, char[] passphrase)

--- a/src/main/java/org/cryptomator/cli/Create.java
+++ b/src/main/java/org/cryptomator/cli/Create.java
@@ -1,0 +1,92 @@
+package org.cryptomator.cli;
+
+import org.cryptomator.cryptofs.CryptoFileSystemProperties;
+import org.cryptomator.cryptofs.CryptoFileSystemProvider;
+import org.cryptomator.cryptolib.api.CryptoException;
+import org.cryptomator.cryptolib.api.CryptorProvider;
+import org.cryptomator.cryptolib.api.Masterkey;
+import org.cryptomator.cryptolib.common.MasterkeyFileAccess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.CharBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.util.concurrent.Callable;
+
+@Command(
+        name = "create",
+        header = "Creates a vault",
+        description = "Creates a new cryptomator vault at the specified path.",
+        parameterListHeading = "%nParameters:%n",
+        headerHeading = "Usage:%n%n",
+        synopsisHeading = "%n",
+        descriptionHeading = "%nDescription:%n%n",
+        optionListHeading = "%nOptions:%n",
+        mixinStandardHelpOptions = true)
+public class Create implements Callable<Integer> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Create.class);
+    private static final byte[] PEPPER = new byte[0];
+    private static final String MASTERKEY_FILE_NAME = "masterkey.cryptomator";
+    private static final URI DEFAULT_KEY_ID = URI.create("masterkeyfile:" + MASTERKEY_FILE_NAME);
+
+    @Spec Model.CommandSpec spec;
+    @Mixin LoggingMixin loggingMixin;
+
+    @Parameters(
+            index = "0",
+            paramLabel = "/path/to/vaultDirectory",
+            description = "Path to the vault directory")
+    Path pathToVault;
+
+    @ArgGroup(multiplicity = "1")
+    PasswordSource passwordSource;
+
+    private SecureRandom csprng = null;
+
+    @Override
+    public Integer call() throws Exception {
+        csprng = SecureRandom.getInstanceStrong();
+
+        createVault(pathToVault);
+
+        LOG.info("Vault created successfully in {}", pathToVault);
+        return 0;
+    }
+
+    private void createVault(Path path) throws IOException {
+        // Throw exception if there's something already there.
+        Files.createDirectory(path);
+
+        try (var passphraseContainer = passwordSource.readPassphrase();
+                var masterkey = Masterkey.generate(csprng)) {
+
+            Path masterkeyFilePath = path.resolve(MASTERKEY_FILE_NAME);
+            MasterkeyFileAccess masterkeyFileAccess = new MasterkeyFileAccess(PEPPER, csprng);
+            masterkeyFileAccess.persist(
+                    masterkey, masterkeyFilePath, CharBuffer.wrap(passphraseContainer.content()));
+
+            try {
+                CryptoFileSystemProperties fsProps =
+                        CryptoFileSystemProperties.cryptoFileSystemProperties()
+                                .withCipherCombo(CryptorProvider.Scheme.SIV_GCM)
+                                .withKeyLoader(ignored -> masterkey.copy())
+                                .build();
+                CryptoFileSystemProvider.initialize(path, fsProps, DEFAULT_KEY_ID);
+            } catch (CryptoException e) {
+                throw new IOException("Vault initialization failed", e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -12,7 +12,7 @@ import picocli.CommandLine.RunLast;
         mixinStandardHelpOptions = true,
         version = "${org.cryptomator.cli.version}",
         description = "Unlocks a cryptomator vault and mounts it into the system.",
-        subcommands = { Unlock.class, ListMounters.class, CommandLine.HelpCommand.class})
+        subcommands = {Create.class, Unlock.class, ListMounters.class, CommandLine.HelpCommand.class})
 public class CryptomatorCli {
 
     private static final Logger LOG = LoggerFactory.getLogger(CryptomatorCli.class);

--- a/src/main/java/org/cryptomator/cli/CryptomatorCli.java
+++ b/src/main/java/org/cryptomator/cli/CryptomatorCli.java
@@ -11,7 +11,7 @@ import picocli.CommandLine.RunLast;
 @Command(name = "cryptomator-cli",
         mixinStandardHelpOptions = true,
         version = "${org.cryptomator.cli.version}",
-        description = "Unlocks a cryptomator vault and mounts it into the system.",
+        description = "Manage Cryptomator vaults from the command line.",
         subcommands = {Create.class, Unlock.class, ListMounters.class, CommandLine.HelpCommand.class})
 public class CryptomatorCli {
 

--- a/src/main/java/org/cryptomator/cli/PasswordSource.java
+++ b/src/main/java/org/cryptomator/cli/PasswordSource.java
@@ -38,6 +38,23 @@ public class PasswordSource {
         throw new IllegalStateException("Passphrase source not specified, but required.");
     }
 
+    void confirmPassphrase() throws IOException {
+        // Don't confirm the passphrase if stdin is piped.
+        if (passphraseStdin == null || System.console() == null) {
+            return;
+        }
+        char[] confirmationInput = System.console().readPassword("Confirm passphrase: ");
+        if (confirmationInput == null) {
+            throw new PassphraseNotConfirmedException("Passphrase confirmation failed (EOF reached).");
+        }
+        try (Passphrase confirmationPassphrase = new Passphrase(confirmationInput)) {
+            System.out.println("\n");
+            if (!Arrays.equals(passphraseStdin, confirmationPassphrase.content)) {
+                throw new PassphraseNotConfirmedException("Passphrase does not match. Please try again.");
+            }
+        }
+    }
+
     private Passphrase readPassphraseFromEnvironment() {
         LOG.debug("Reading passphrase from env variable '{}'", passphraseEnvironmentVariable);
         var tmp = System.getenv(passphraseEnvironmentVariable);
@@ -104,6 +121,12 @@ public class PasswordSource {
         ReadingEnvironmentVariableFailedException(String msg) {
             super(msg);
         }
+    }
+
+    static class PassphraseNotConfirmedException extends PasswordSourceException {
+      PassphraseNotConfirmedException(String msg) {
+        super(msg);
+      }
     }
 
     record Passphrase(char[] content) implements AutoCloseable {


### PR DESCRIPTION
This PR adds a new subcommand for vault creation with default vault/security parameters. The implementation was mostly copied from the Cryptomator app [createVault](https://github.com/cryptomator/cryptomator/blob/472b10a8a4d1d5211ce8d8b4941457485eb0164a/src/main/java/org/cryptomator/ui/addvaultwizard/CreateNewVaultPasswordController.java#L184) and the other subcommands.

Example usage and testing:
```
mkdir -p /mnt/vault

echo test123 | cryptomator-cli create /tmp/testVault --password:stdin

echo test123 | cryptomator-cli unlock \
		--password:stdin \
		--mounter=org.cryptomator.frontend.fuse.mount.LinuxFuseMountProvider \
		--mountPoint /mnt/vault \
		/tmp/testVault
```

Output:
```
Enter value for --password:stdin (Passphrase, read from STDIN):

[main] INFO  o.c.cli.Create - Vault created successfully in /tmp/testVault
Enter value for --password:stdin (Passphrase, read from STDIN):

[main] INFO  o.c.cli.Unlock - Unlocked and mounted vault successfully to file:///mnt/vault/
```

Fixes #31 