### PR TITLE
Update to JDK 25

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -44,8 +44,8 @@ permissions:
   contents: write
 
 env:
-  JAVA_DIST: 'zulu'
-  JAVA_VERSION: '24.0.0+36'
+  JAVA_DIST: 'temurin'
+  JAVA_VERSION: '25.0.4+7'
   VERSION_NUM: ${{ inputs.semVerNum || '99.99.99' }}
   VERSION_SUFFIX: ${{ inputs.semVerSuffix || '' }}
 

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -52,8 +52,8 @@ permissions:
   contents: write
 
 env:
-  JAVA_DIST: 'zulu'
-  JAVA_VERSION: '24.0.0+36'
+  JAVA_DIST: 'temurin'
+  JAVA_VERSION: '25.0.4+7'
   VERSION_NUM: ${{ inputs.semVerNum || '99.99.99' }}
   REVISION_NUM: ${{ inputs.revisionNum || '0' }}
   VERSION_SUFFIX: ${{ inputs.semVerSuffix || '' }}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -49,8 +49,8 @@ permissions:
   contents: write
 
 env:
-  JAVA_DIST: 'zulu'
-  JAVA_VERSION: '24.0.0+36'
+  JAVA_DIST: 'temurin'
+  JAVA_VERSION: '25.0.4+7'
   VERSION_NUM: ${{ inputs.semVerNum || '99.99.99' }}
   VERSION_SUFFIX: ${{ inputs.semVerSuffix || '' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 #v4.8.0
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Ensure to use tagged version
         run: ./mvnw versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/} # use shell parameter expansion to strip of 'refs/tags'

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,8 +9,8 @@ permissions:
   contents: write
 
 env:
-  JAVA_DIST: 'zulu'
-  JAVA_VERSION: '24.0.0+36'
+  JAVA_DIST: 'temurin'
+  JAVA_VERSION: '25.0.4+7'
 
 defaults:
   run:

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -25,8 +25,8 @@ on:
         value: ${{ jobs.determine-version.outputs.type }}
 
 env:
-  JAVA_DIST: 'zulu'
-  JAVA_VERSION: '24.0.0+36'
+  JAVA_DIST: 'temurin'
+  JAVA_VERSION: '25.0.4+7'
 
 jobs:
   determine-version:

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<jdk.version>24</jdk.version>
+		<jdk.version>25</jdk.version>
 
 		<!--jpackage stuff -->
 		<!-- Group IDs of jars that need to stay on the class path for now


### PR DESCRIPTION
JDK 26 is not used due to https://bugs.openjdk.org/browse/JDK-8389112